### PR TITLE
align date with article title

### DIFF
--- a/pages/blog.js
+++ b/pages/blog.js
@@ -35,10 +35,10 @@ export default function Blog({ items }) {
 								.filter((item) => item.isoDate.startsWith(year))
 								.map((article) => (
 									<div key={article.link} className="grid grid-cols-5">
-										<span className="text-sm md:text-base text-gray-600 dark:text-gray-400 mr-4 self-center">
+										<span className="text-sm md:text-base text-gray-600 dark:text-gray-400 mr-4">
 											{format(new Date(article.isoDate), "LLL dd")}
 										</span>
-										<div className="col-span-4">
+										<div className="col-span-4 space-y-2">
 											<a
 												className="text-base md:text-lg"
 												href={article.link}


### PR DESCRIPTION
## Description
Aligning date with blog title. Before  it was aligned to the center. Now they are on the same level

## Linked Issue

fixes #99

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots (if appropriate)

## checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I've added a funny image
